### PR TITLE
feat: 서브 나비게이션 바의 아이템 길이가 길 경우 말 줄임표

### DIFF
--- a/src/components/layout/SubNavigationBarItem.tsx
+++ b/src/components/layout/SubNavigationBarItem.tsx
@@ -46,7 +46,17 @@ function SubNavigationBarItem({
             <SvgIcon />
           </ListItemIcon>
         ) : null}
-        <ListItemText primary={text} secondary={subText} />
+        <ListItemText
+          primary={text}
+          secondary={subText}
+          primaryTypographyProps={{
+            sx: {
+              textOverflow: "ellipsis",
+              overflow: "hidden",
+              whiteSpace: "nowrap",
+            },
+          }}
+        />
       </ListItemButton>
     </ListItem>
   );


### PR DESCRIPTION
일정한 높이를 유지할 수 있도록 말 줄임표 기능을 도입