### PR TITLE
fix: '사건 - 사건상세 - 지출정보' 등록 버튼 수정

### DIFF
--- a/src/components/case/expense/table/button/CaseExpenseDeleteButton.tsx
+++ b/src/components/case/expense/table/button/CaseExpenseDeleteButton.tsx
@@ -45,7 +45,6 @@ function CaseExpenseDeleteButton({ item }: Props) {
       sx={{ marginLeft: 1, marginRight: 1 }}
       size="small"
       variant="outlined"
-      fullWidth
       onClick={handleClick}
     >
       <DeleteIcon />

--- a/src/components/case/expense/table/button/CaseExpenseEditButton.tsx
+++ b/src/components/case/expense/table/button/CaseExpenseEditButton.tsx
@@ -26,7 +26,6 @@ function CaseExpenseEditButton({ item }: Props) {
       sx={{ marginLeft: 1, marginRight: 1 }}
       size="small"
       variant="outlined"
-      fullWidth
       onClick={handleClick}
     >
       <EditIcon />

--- a/src/components/case/expense/table/button/CaseExpenseEditConfirmButton.tsx
+++ b/src/components/case/expense/table/button/CaseExpenseEditConfirmButton.tsx
@@ -51,7 +51,6 @@ function CaseExpenseEditConfirmButton({ item }: Props) {
       sx={{ marginLeft: 1, marginRight: 1 }}
       size="small"
       variant="contained"
-      fullWidth
       onClick={handleClick}
     >
       <CheckIcon />

--- a/src/components/case/expense/table/row/CaseExpenseDataRow.tsx
+++ b/src/components/case/expense/table/row/CaseExpenseDataRow.tsx
@@ -13,19 +13,19 @@ type Props = {
 
 function CaseExpenseDataRow({ item }: Props) {
   return (
-    <Box sx={{ display: "flex", width: "100%" }}>
-      <Box sx={{ width: "25%" }}>
+    <Box sx={{ display: "flex", width: "100%", justifyContent: "center" }}>
+      <Box sx={{ width: "15%" }}>
         <CaseExpenseSpeningAtCell item={item} />
       </Box>
-      <Box sx={{ width: "25%" }}>
+      <Box sx={{ width: "55%" }}>
         <CaseExpenseContentsCell item={item} />
       </Box>
-      <Box sx={{ width: "25%" }}>
+      <Box sx={{ width: "15%" }}>
         <CaseExpenseAmountCell item={item} />
       </Box>
       <Box
         sx={{
-          width: "12.5%",
+          width: "20%",
           display: "flex",
           justifyContent: "center",
           alignItems: "center",
@@ -36,15 +36,6 @@ function CaseExpenseDataRow({ item }: Props) {
         ) : (
           <CaseExpenseEditButton item={item} />
         )}
-      </Box>
-      <Box
-        sx={{
-          width: "12.5%",
-          display: "flex",
-          justifyContent: "center",
-          alignItems: "center",
-        }}
-      >
         <CaseExpenseDeleteButton item={item} />
       </Box>
     </Box>

--- a/src/components/case/expense/table/row/CaseExpenseHeaderRow.tsx
+++ b/src/components/case/expense/table/row/CaseExpenseHeaderRow.tsx
@@ -1,8 +1,7 @@
 import { useSetRecoilState } from "recoil";
 import caseExpenseAddPopUpOpenState from "../../../../../states/case/info/expense/CaseExpenseAddPopUpOpenState.tsx";
 import Box from "@mui/material/Box";
-import AddCircleIcon from "@mui/icons-material/AddCircle";
-import IconButton from "@mui/material/IconButton";
+import { Button } from "@mui/material";
 
 function CaseExpenseHeaderRow() {
   const setExpenseAddPopUpOpen = useSetRecoilState(
@@ -14,58 +13,63 @@ function CaseExpenseHeaderRow() {
   };
 
   return (
-    <Box sx={{ display: "flex", background: "#2196f3", color: "white" }}>
+    <Box
+      sx={{
+        display: "flex",
+        background: "#2196f3",
+        color: "white",
+        width: "100%",
+      }}
+    >
       <Box
         sx={{
-          width: "100%",
+          width: "15%",
           height: 40,
           display: "flex",
           justifyContent: "center",
           alignItems: "center",
         }}
       >
-        <Box>
-          <b>날짜</b>
-        </Box>
+        <b>날짜</b>
       </Box>
       <Box
         sx={{
-          width: "100%",
+          width: "55%",
           height: 40,
           display: "flex",
           justifyContent: "center",
           alignItems: "center",
         }}
       >
-        <Box>
-          <b>내용</b>
-        </Box>
+        <b>내용</b>
       </Box>
       <Box
         sx={{
-          width: "100%",
+          width: "15%",
           height: 40,
           display: "flex",
           justifyContent: "center",
           alignItems: "center",
         }}
       >
-        <Box>
-          <b>금액</b>
-        </Box>
+        <b>금액</b>
       </Box>
       <Box
         sx={{
-          width: "100%",
+          width: "20%",
           height: 40,
           display: "flex",
           justifyContent: "center",
           alignItems: "center",
         }}
       >
-        <IconButton onClick={handleExpenseAddButtonClick}>
-          <AddCircleIcon color="primary" />
-        </IconButton>
+        <Button
+          variant="contained"
+          sx={{ width: "50%", color: "secondary" }}
+          onClick={handleExpenseAddButtonClick}
+        >
+          등록
+        </Button>
       </Box>
     </Box>
   );


### PR DESCRIPTION
지출정보 테이블의 등록 버튼인 '+' 기호를 직관적인 등록 버튼으로 변경했음.