### PR TITLE
사건 정보 요청 위치 변경

### DIFF
--- a/src/components/case/CaseDetailPage.tsx
+++ b/src/components/case/CaseDetailPage.tsx
@@ -1,5 +1,5 @@
 import { Box } from "@mui/material";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import Info from "./advice/Adviceinfo";
 import TabBar, { TabItem } from "../common/TabBar";
 import ExpenseInfo from "./expense/ExpenseInfo.tsx";
@@ -9,8 +9,13 @@ import CaseBasicInfoCard from "./common/CaseBasicInfoCard.tsx";
 import CaseCostInfoCard from "./common/CaseCostInfoCard.tsx";
 import CaseEmployeeInfoCard from "./common/CaseEmployeeInfoCard.tsx";
 import CaseClientInfoCard from "./common/CaseClientInfoCard.tsx";
-import { useRecoilState } from "recoil";
+import { useRecoilState, useRecoilValue, useSetRecoilState } from "recoil";
 import caseTabIdState from "../../states/case/CaseTabIdState.tsx";
+import caseIdState from "../../states/case/CaseIdState.tsx";
+import caseInfoState, {
+  CaseInfoType,
+} from "../../states/case/info/caseInfoState.tsx";
+import request, { RequestSuccessHandler } from "../../lib/request.ts";
 
 function CaseDetailPage() {
   const [caseTabId, setCaseTabId] = useRecoilState(caseTabIdState);
@@ -49,6 +54,24 @@ function CaseDetailPage() {
       ),
     },
   ]);
+
+  const caseId = useRecoilValue(caseIdState);
+  const setCaseInfo = useSetRecoilState(caseInfoState);
+
+  useEffect(() => {
+    if (caseId === null) {
+      return;
+    }
+
+    const handleSuccessHandler: RequestSuccessHandler = (res) => {
+      const newCaseInfo: CaseInfoType = res.data["data"];
+      setCaseInfo(newCaseInfo);
+    };
+
+    request("GET", `/lawsuits/${caseId}`, {
+      onSuccess: handleSuccessHandler,
+    });
+  }, [caseId]);
 
   return (
     <Box>

--- a/src/components/case/reception/CaseReceptionTab.tsx
+++ b/src/components/case/reception/CaseReceptionTab.tsx
@@ -1,32 +1,7 @@
 import Box from "@mui/material/Box";
 import CaseReceptionInfoCard from "./CaseReceptionInfoCard.tsx";
-import { useRecoilValue, useSetRecoilState } from "recoil";
-import { useEffect } from "react";
-import caseIdState from "../../../states/case/CaseIdState.tsx";
-import caseInfoState, {
-  CaseInfoType,
-} from "../../../states/case/info/caseInfoState.tsx";
-import request, { RequestSuccessHandler } from "../../../lib/request.ts";
 
 function CaseReceptionTab() {
-  const caseId = useRecoilValue(caseIdState);
-  const setCaseInfo = useSetRecoilState(caseInfoState);
-
-  useEffect(() => {
-    if (caseId === null) {
-      return;
-    }
-
-    const handleSuccessHandler: RequestSuccessHandler = (res) => {
-      const newCaseInfo: CaseInfoType = res.data["data"];
-      setCaseInfo(newCaseInfo);
-    };
-
-    request("GET", `/lawsuits/${caseId}`, {
-      onSuccess: handleSuccessHandler,
-    });
-  }, [caseId]);
-
   return (
     <Box
       sx={{


### PR DESCRIPTION
사건 정보 탭에서 요청하는 것 보다  컴포넌트인 사건 상세 페이지에서 요청하는 것이 맞다고 생각해서 요청 위치 변경