### PR TITLE
fix: 의뢰인-사건정보 탭 페이징 및 사건-사건목록 탭 검색 및 페이징

### DIFF
--- a/src/components/case/CaseListPage.tsx
+++ b/src/components/case/CaseListPage.tsx
@@ -1,10 +1,12 @@
 import Box from "@mui/material/Box";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { useRecoilValue, useSetRecoilState } from "recoil";
-import request, { RequestSuccessHandler } from "../../lib/request";
+import { useRecoilValue } from "recoil";
+import request, {
+  RequestFailHandler,
+  RequestSuccessHandler,
+} from "../../lib/request";
 import { LawsuitStatus } from "../../mock/lawsuit/lawsuitTable";
-import caseIdState from "../../states/case/CaseIdState";
 import clientIdState from "../../states/client/ClientIdState";
 import ClientInfoCard from "../client/ClientInfoCard.tsx";
 import CaseListTable from "./CaseListTable.tsx";
@@ -17,40 +19,142 @@ import { LawsuitInfo } from "./type/LawsuitInfo.tsx";
 
 function CaseListPage() {
   const clientId = useRecoilValue(clientIdState);
-  const setCaseId = useSetRecoilState(caseIdState);
   const navigate = useNavigate();
   const [cases, setCases] = useState<LawsuitInfo[]>([]);
-  const [lawsuitStatus, setLawsuitStatus] = useState<LawsuitStatus | null>(
-    null,
-  );
-  const totalLength = cases.length;
-  const aLength = cases.filter((item) => item.lawsuitStatus === "등록").length;
-  const bLength = cases.filter((item) => item.lawsuitStatus === "진행").length;
-  const cLength = cases.filter((item) => item.lawsuitStatus === "종결").length;
+  const [caseList, setCaseList] = useState<LawsuitInfo[]>([]);
+  //for paging
+  const [page, setPage] = useState(0);
+  const [rowsPerPage, setRowsPerPage] = useState(5);
+  const [count, setCount] = useState(0);
+  const [searchLawsuitStatus, setSearchLawsuitStatus] =
+    useState<LawsuitStatus | null>(null);
+  const [searchWord, setSearchWord] = useState<string | null>(null);
+  const [curSearchWord, setCurSearchWord] = useState<string | null>(null);
+
+  const totalLength = caseList.length;
+  const aLength = caseList.filter(
+    (item) => item.lawsuitStatus === "REGISTRATION",
+  ).length;
+  const bLength = caseList.filter(
+    (item) => item.lawsuitStatus === "PROCEEDING",
+  ).length;
+  const cLength = caseList.filter(
+    (item) => item.lawsuitStatus === "CLOSING",
+  ).length;
+
+  const prevDependencies = useRef({
+    searchLawsuitStatus,
+    rowsPerPage,
+    page,
+  });
 
   useEffect(() => {
     if (typeof clientId !== "number") {
       // TODO
       return;
     }
+
+    // page만 변화했는지 체크
+    if (
+      prevDependencies.current.searchLawsuitStatus === searchLawsuitStatus &&
+      prevDependencies.current.rowsPerPage === rowsPerPage &&
+      prevDependencies.current.page !== page
+    ) {
+      searchRequest(false, true);
+    } else {
+      searchRequest(true, true);
+    }
+
+    prevDependencies.current = {
+      searchLawsuitStatus,
+      rowsPerPage,
+      page,
+    };
+  }, [clientId, rowsPerPage, page, searchLawsuitStatus, searchWord]);
+
+  // 검색
+  const searchRequest = (isInitPage?: boolean, isGetBackWord?: boolean) => {
+    if (isInitPage) {
+      setPage(0);
+    }
+    if (isGetBackWord) {
+      setCurSearchWord(searchWord);
+    }
+
     const handleRequestSuccess: RequestSuccessHandler = (res) => {
-      const body: {
+      function mapLawsuitStatus(status: string) {
+        switch (status) {
+          case "REGISTRATION":
+            return "등록";
+          case "PROCEEDING":
+            return "진행";
+          case "CLOSING":
+            return "종결";
+          default:
+            return status as LawsuitStatus;
+        }
+      }
+
+      const lawsuitData: {
         lawsuitList: LawsuitInfo[];
-        pageRange: { startPage: number; endPage: number };
+        count: number;
       } = res.data;
-      setCases(body.lawsuitList);
-      setCaseId(body.lawsuitList[0]?.id);
+
+      const mappedLawsuitList = lawsuitData.lawsuitList.map((item) => ({
+        ...item,
+        lawsuitStatus: mapLawsuitStatus(item.lawsuitStatus),
+      }));
+
+      setCases(mappedLawsuitList);
+      setCount(lawsuitData.count);
     };
 
-    request("GET", `/lawsuits/clients/${clientId}?curPage=1&itemsPerPage=5`, {
-      onSuccess: handleRequestSuccess,
+    const handleRequestFail: RequestFailHandler = (e) => {
+      alert((e.response.data as { code: string; message: string }).message);
+    };
+
+    request("GET", `/lawsuits/clients/${clientId}`, {
+      withToken: true,
       useMock: false,
+      params: {
+        curPage: (page + 1).toString(),
+        rowsPerPage: rowsPerPage.toString(),
+        searchWord: searchWord || "",
+      },
+      onSuccess: handleRequestSuccess,
+      onFail: handleRequestFail,
     });
-  }, [clientId]);
+  };
+
+  // 의뢰인별 전체 사건 리스트
+  useEffect(() => {
+    if (count === 0) {
+      return;
+    }
+    const handleCaseListRequestSuccess: RequestSuccessHandler = (res) => {
+      const lawsuitData: {
+        lawsuitList: LawsuitInfo[];
+        count: number;
+      } = res.data;
+
+      setCaseList(lawsuitData.lawsuitList);
+    };
+
+    request("GET", `/lawsuits/clients/${clientId}`, {
+      useMock: false,
+      withToken: true,
+      params: {
+        curPage: "1",
+        rowsPerPage: count.toString(),
+        searchWord: "",
+      },
+      onSuccess: handleCaseListRequestSuccess,
+    });
+  }, [clientId, count]);
 
   let filteredCases: LawsuitInfo[];
 
-  switch (lawsuitStatus) {
+  switch (searchLawsuitStatus) {
     case "등록":
       filteredCases = cases.filter((item) => item.lawsuitStatus === "등록");
       break;
@@ -68,6 +172,14 @@ function CaseListPage() {
     navigate("/cases/new");
   };
 
+  const [triggerSearch, setTriggerSearch] = useState(false);
+  useEffect(() => {
+    if (triggerSearch) {
+      searchRequest(true, false);
+      setTriggerSearch(false);
+    }
+  }, [triggerSearch]);
+
   return (
     <Box
       sx={{
@@ -80,7 +192,13 @@ function CaseListPage() {
       <ClientInfoCard />
       <Card>
         <CardContent>
-          <TextField size="small" fullWidth />
+          <TextField
+            size="small"
+            placeholder="사건명, 사건번호 검색"
+            fullWidth
+            value={curSearchWord}
+            onChange={(e) => setCurSearchWord(e.target.value)}
+          />
           <Box
             sx={{
               display: "flex",
@@ -92,35 +210,43 @@ function CaseListPage() {
           >
             <Box sx={{ display: "flex", gap: 1 }}>
               <Chip
-                variant={lawsuitStatus === null ? "filled" : "outlined"}
+                variant={searchLawsuitStatus === null ? "filled" : "outlined"}
                 label={`전체 (${totalLength})`}
                 onClick={() => {
-                  setLawsuitStatus(null);
+                  setSearchLawsuitStatus(null);
                 }}
               />
               <Chip
-                variant={lawsuitStatus === "등록" ? "filled" : "outlined"}
+                variant={searchLawsuitStatus === "등록" ? "filled" : "outlined"}
                 label={`등록 (${aLength})`}
                 onClick={() => {
-                  setLawsuitStatus("등록");
+                  setSearchLawsuitStatus("등록");
                 }}
               />
               <Chip
-                variant={lawsuitStatus === "진행" ? "filled" : "outlined"}
+                variant={searchLawsuitStatus === "진행" ? "filled" : "outlined"}
                 label={`진행 (${bLength})`}
                 onClick={() => {
-                  setLawsuitStatus("진행");
+                  setSearchLawsuitStatus("진행");
                 }}
               />
               <Chip
-                variant={lawsuitStatus === "종결" ? "filled" : "outlined"}
+                variant={searchLawsuitStatus === "종결" ? "filled" : "outlined"}
                 label={`종결 (${cLength})`}
                 onClick={() => {
-                  setLawsuitStatus("종결");
+                  setSearchLawsuitStatus("종결");
                 }}
               />
             </Box>
-            <Button variant="contained">검색</Button>
+            <Button
+              variant="contained"
+              onClick={() => {
+                setSearchWord(curSearchWord);
+                setTriggerSearch(true);
+              }}
+            >
+              검색
+            </Button>
           </Box>
         </CardContent>
       </Card>
@@ -132,6 +258,11 @@ function CaseListPage() {
               navigate(`/cases/${item.id}?client=${clientId}`);
             },
           }))}
+          count={count}
+          page={page}
+          setPage={setPage}
+          rowsPerPage={rowsPerPage}
+          setRowsPerPage={setRowsPerPage}
         />
       </Box>
       <Button

--- a/src/components/case/CaseListTable.tsx
+++ b/src/components/case/CaseListTable.tsx
@@ -7,23 +7,60 @@ import TableHead from "@mui/material/TableHead";
 import TableRow from "@mui/material/TableRow";
 import { delimiter } from "../../lib/convert.ts";
 import { LawsuitInfo } from "./type/LawsuitInfo.tsx";
+import { TableFooter, TablePagination } from "@mui/material";
+import React from "react";
 
 type Props = {
   cases: (LawsuitInfo & { onClick: () => void })[];
+  count: number;
+  page: number;
+  setPage: React.Dispatch<React.SetStateAction<number>>;
+  rowsPerPage: number;
+  setRowsPerPage: React.Dispatch<React.SetStateAction<number>>;
 };
 
-function CaseListTable({ cases }: Props) {
+function CaseListTable({
+  cases,
+  count,
+  page,
+  setPage,
+  rowsPerPage,
+  setRowsPerPage,
+}: Props) {
+  const handleChangePage = (_event: unknown, newPage: number) => {
+    setPage(newPage);
+  };
+
+  const handleChangeRowsPerPage = (
+    event: React.ChangeEvent<HTMLInputElement>,
+  ) => {
+    setRowsPerPage(+event.target.value);
+    setPage(0);
+  };
+
   return (
     <TableContainer component={Paper}>
       <Table sx={{ minWidth: 650 }} aria-label="simple table">
-        <TableHead>
+        <TableHead sx={{ background: "#2196f3" }}>
           <TableRow>
-            <TableCell></TableCell>
-            <TableCell align="left">사건명</TableCell>
-            <TableCell align="left">사건번호</TableCell>
-            <TableCell align="left">사건상태</TableCell>
-            <TableCell align="left">의뢰비</TableCell>
-            <TableCell align="left">성공보수</TableCell>
+            <TableCell sx={{ color: "white" }} align="center">
+              <b>번호</b>
+            </TableCell>
+            <TableCell sx={{ color: "white" }} align="center">
+              <b>사건명</b>
+            </TableCell>
+            <TableCell sx={{ color: "white" }} align="center">
+              <b>사건번호</b>
+            </TableCell>
+            <TableCell sx={{ color: "white" }} align="center">
+              <b>사건상태</b>
+            </TableCell>
+            <TableCell sx={{ color: "white" }} align="center">
+              <b>의뢰비</b>
+            </TableCell>
+            <TableCell sx={{ color: "white" }} align="center">
+              <b>성공보수</b>
+            </TableCell>
           </TableRow>
         </TableHead>
         <TableBody>
@@ -37,21 +74,37 @@ function CaseListTable({ cases }: Props) {
               }}
               onClick={item.onClick}
             >
-              <TableCell component="th" scope="row">
-                {index + 1}
+              <TableCell align="center" component="th" scope="row">
+                {page * rowsPerPage + index + 1}
               </TableCell>
-              <TableCell align="left">{item.name}</TableCell>
-              <TableCell align="left">{item.lawsuitNum}</TableCell>
-              <TableCell align="left">{item.lawsuitStatus}</TableCell>
-              <TableCell align="left">
+              <TableCell align="center">{item.name}</TableCell>
+              <TableCell align="center">{item.lawsuitNum}</TableCell>
+              <TableCell align="center">{item.lawsuitStatus}</TableCell>
+              <TableCell align="center">
                 {delimiter(item.commissionFee)}
               </TableCell>
-              <TableCell align="left">
+              <TableCell align="center">
                 {delimiter(item.contingentFee)}
               </TableCell>
             </TableRow>
           ))}
         </TableBody>
+        <TableFooter>
+          <TableRow>
+            <TableCell colSpan={7} style={{ textAlign: "center" }}>
+              <TablePagination
+                sx={{ display: "inline-flex", verticalAlign: "middle" }}
+                rowsPerPageOptions={[5, 10, 25]}
+                component="div"
+                count={count}
+                page={page}
+                onPageChange={handleChangePage}
+                rowsPerPage={rowsPerPage}
+                onRowsPerPageChange={handleChangeRowsPerPage}
+              />
+            </TableCell>
+          </TableRow>
+        </TableFooter>
       </Table>
     </TableContainer>
   );

--- a/src/components/case/type/LawsuitInfo.tsx
+++ b/src/components/case/type/LawsuitInfo.tsx
@@ -1,5 +1,4 @@
 export type LawsuitType = "형사" | "민사";
-export type LawsuitStatus = "등록" | "진행" | "종결";
 
 export type LawsuitInfo = {
   id: number;
@@ -8,7 +7,7 @@ export type LawsuitInfo = {
   courtId: number;
   commissionFee: number;
   contingentFee: number;
-  lawsuitStatus: LawsuitStatus;
+  lawsuitStatus: string;
   lawsuitNum: string;
   result: string;
   judgementDate: Date;

--- a/src/components/client/ClientCaseListTab.tsx
+++ b/src/components/client/ClientCaseListTab.tsx
@@ -1,42 +1,60 @@
 import Box from "@mui/material/Box";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { useRecoilValue } from "recoil";
+import { useRecoilValue, useSetRecoilState } from "recoil";
 import request, { RequestSuccessHandler } from "../../lib/request";
 import clientIdState from "../../states/client/ClientIdState";
 import CaseListTable from "../case/CaseListTable.tsx";
 import { LawsuitInfo } from "../case/type/LawsuitInfo.tsx";
-import { PagingInfo } from "../common/type/PagingInfo.tsx";
+import lawsuitsPageState from "../../states/case/info/lawsuitsPaging/LawsuitsPageState.tsx";
 
 function ClientCaseListTab() {
   const clientId = useRecoilValue(clientIdState);
   const navigate = useNavigate();
   const [cases, setCases] = useState<LawsuitInfo[]>([]);
 
+  //for paging
+  const page = useRecoilValue(lawsuitsPageState);
+  const setPage = useSetRecoilState(lawsuitsPageState);
+  const [rowsPerPage, setRowsPerPage] = useState(5);
+  const [count, setCount] = useState(0);
+
+  const prevDependencies = useRef({
+    rowsPerPage,
+    page,
+  });
+
   useEffect(() => {
     if (typeof clientId !== "number") {
       // TODO
       return;
     }
+
+    prevDependencies.current = {
+      rowsPerPage,
+      page,
+    };
+
     const handleRequestSuccess: RequestSuccessHandler = (res) => {
       const lawsuitData: {
         lawsuitList: LawsuitInfo[];
-        pageRange: PagingInfo;
+        count: number;
       } = res.data;
-      console.log(lawsuitData);
+
       setCases(lawsuitData.lawsuitList);
+      setCount(lawsuitData.count);
     };
 
     request("GET", `/lawsuits/clients/${clientId}`, {
       useMock: false,
       withToken: true,
       params: {
-        curPage: "1",
-        itemsPerPage: "10",
+        curPage: (page + 1).toString(),
+        rowsPerPage: rowsPerPage.toString(),
       },
       onSuccess: handleRequestSuccess,
     });
-  }, [clientId]);
+  }, [clientId, rowsPerPage, page]);
 
   return (
     <Box>
@@ -47,6 +65,11 @@ function ClientCaseListTab() {
             navigate(`/cases/${item.id}?client=${clientId}`);
           },
         }))}
+        count={count}
+        page={page}
+        setPage={setPage}
+        rowsPerPage={rowsPerPage}
+        setRowsPerPage={setRowsPerPage}
       />
     </Box>
   );

--- a/src/components/client/statistics/ClientCaseStatisticsChart.tsx
+++ b/src/components/client/statistics/ClientCaseStatisticsChart.tsx
@@ -26,13 +26,17 @@ function ClientCaseStatisticsChart() {
     }
 
     const handleRequestSuccess: RequestSuccessHandler = (res) => {
-      const lawsuitData: LawsuitInfo[] = res.data;
+      const lawsuitData: LawsuitInfo[] = res.data.lawsuitList;
       setCases(lawsuitData);
     };
 
-    request("GET", `/lawsuits/${clientId}`, {
+    request("GET", `/lawsuits/clients/${clientId}`, {
       useMock: false,
       withToken: true,
+      params: {
+        curPage: "0",
+        rowsPerPage: "0",
+      },
       onSuccess: handleRequestSuccess,
     });
   }, [clientId]);

--- a/src/components/client/statistics/ClientCaseStatisticsChart.tsx
+++ b/src/components/client/statistics/ClientCaseStatisticsChart.tsx
@@ -36,6 +36,7 @@ function ClientCaseStatisticsChart() {
       params: {
         curPage: "0",
         rowsPerPage: "0",
+        searchWord: "",
       },
       onSuccess: handleRequestSuccess,
     });

--- a/src/components/common/type/PagingInfo.tsx
+++ b/src/components/common/type/PagingInfo.tsx
@@ -1,4 +1,0 @@
-export type PagingInfo = {
-  startPage: number;
-  endPage: number;
-};


### PR DESCRIPTION
의뢰인-사건정보 탭 페이징 구현 완료
사건-사건목록 탭 검색 및 페이징 구현 완료

사건 리스트를 보여주는 컴포넌트인 CaseListTable은 다른 컴포넌트들에서 공통으로 사용되기 때문에
Props로 넘겨주는 값들을 전역으로 관리해야할지 의문..