### PR TITLE
[사건-지출] 지출 증빙자료 파일 업로드 기능 구현

### DIFF
--- a/src/components/case/expense/search/CaseExpenseSearchBox.tsx
+++ b/src/components/case/expense/search/CaseExpenseSearchBox.tsx
@@ -108,7 +108,7 @@ function CaseExpenseSearchBox() {
       }: { expenses: CaseExpenseRowType[]; size: number } = res.data;
       setCaseExpenses(
         expenses.map((item) => {
-          return { ...item, editable: false };
+          return { ...item, editable: false, isSelected: false };
         }),
       );
       setSize(size);

--- a/src/components/case/expense/table/CaseExpenseBillTable.tsx
+++ b/src/components/case/expense/table/CaseExpenseBillTable.tsx
@@ -5,12 +5,57 @@ import { useRecoilState, useRecoilValue } from "recoil";
 import CaseExpenseBillDataRow from "./row/CaseExpenseBillDataRow.tsx";
 import caseExpenseBillIdState from "../../../../states/case/info/expense/CaseExpenseBillIdState.tsx";
 import Button from "@mui/material/Button";
-import caseExpenseBillState from "../../../../states/case/info/expense/CaseExpenseBIllRowType.tsx";
+import caseExpenseBillState, {
+  CaseExpenseBillRowType,
+} from "../../../../states/case/info/expense/CaseExpenseBillState.tsx";
+import caseExpenseIdState from "../../../../states/case/info/expense/CaseExpenseIdState.tsx";
+import { useEffect, useState } from "react";
+import requestDeprecated, {
+  RequestFailHandler,
+  RequestSuccessHandler,
+} from "../../../../lib/requestDeprecated.ts";
+import caseExpensesState from "../../../../states/case/info/expense/CaseExpensesState.tsx";
 
 function CaseExpenseBillTable() {
   const theme = useTheme();
+  const expenses = useRecoilValue(caseExpensesState);
+  const [expenseId, setExpenseId] = useRecoilState(caseExpenseIdState);
   const [expenseBill, setExpenseBill] = useRecoilState(caseExpenseBillState);
   const expenseBillId = useRecoilValue(caseExpenseBillIdState);
+  const [trigger, setTrigger] = useState(false);
+
+  useEffect(() => {
+    if (expenses.length > 0) {
+      setExpenseId(expenses[0].id);
+    }
+  }, [expenses]);
+
+  useEffect(() => {
+    if (!trigger) {
+      return;
+    }
+    const handleRequestSuccess: RequestSuccessHandler = (res) => {
+      const expenseBill: CaseExpenseBillRowType[] = res.data;
+
+      setExpenseBill(
+        expenseBill.map((item) => {
+          return { ...item, editable: false };
+        }),
+      );
+
+      setTrigger(false);
+    };
+
+    const handleRequestFail: RequestFailHandler = (e) => {
+      alert((e.response.data as { code: string; message: string }).message);
+    };
+
+    requestDeprecated("GET", `/expenses/${expenseId}/bill`, {
+      onSuccess: handleRequestSuccess,
+      onFail: handleRequestFail,
+    });
+  }, [trigger]);
+
   return (
     <Box
       sx={{
@@ -22,7 +67,7 @@ function CaseExpenseBillTable() {
     >
       <Box sx={{ marginBottom: 2 }}></Box>
       <Divider />
-      <CaseExpenseBillHeaderRow />
+      <CaseExpenseBillHeaderRow setTrigger={setTrigger} />
       <Divider />
       {expenseBill.length > 0 ? (
         expenseBill.map((item) => (
@@ -45,6 +90,10 @@ function CaseExpenseBillTable() {
           자료가 없습니다.
         </Box>
       )}
+      {expenseBill.length > 0 &&
+        Array.from({ length: 5 - expenseBill.length }).map((_, index) => (
+          <Box key={index} sx={{ width: "100%", height: 40 }}></Box>
+        ))}
       <Divider sx={{ marginTop: 1, marginBottom: 1 }} />
       <Box
         sx={{

--- a/src/components/case/expense/table/CaseExpenseTable.tsx
+++ b/src/components/case/expense/table/CaseExpenseTable.tsx
@@ -44,7 +44,7 @@ function CaseExpenseTable() {
 
       setExpenses(
         expenses.map((item) => {
-          return { ...item, editable: false };
+          return { ...item, editable: false, isSelected: false };
         }),
       );
       setSize(size);
@@ -94,9 +94,10 @@ function CaseExpenseTable() {
           지출정보가 존재하지 않습니다.
         </Box>
       )}
-      {Array.from({ length: 5 - expenses.length }).map((_, index) => (
-        <Box key={index} sx={{ width: "100%", height: 40 }}></Box>
-      ))}
+      {expenses.length > 0 &&
+        Array.from({ length: 5 - expenses.length }).map((_, index) => (
+          <Box key={index} sx={{ width: "100%", height: 40 }}></Box>
+        ))}
       <Divider sx={{ marginTop: 1, marginBottom: 1 }} />
       <Box
         sx={{
@@ -118,7 +119,7 @@ function CaseExpenseTable() {
                 }: { expenses: CaseExpenseRowType[]; size: number } = res.data;
                 setExpenses(
                   expenses.map((item) => {
-                    return { ...item, editable: false };
+                    return { ...item, editable: false, isSelected: false };
                   }),
                 );
                 setSize(size);
@@ -150,7 +151,7 @@ function CaseExpenseTable() {
                 }: { expenses: CaseExpenseRowType[]; size: number } = res.data;
                 setExpenses(
                   expenses.map((item) => {
-                    return { ...item, editable: false };
+                    return { ...item, editable: false, isSelected: false };
                   }),
                 );
                 setSize(size);

--- a/src/components/case/expense/table/button/CaseExpenseBillDeleteButton.tsx
+++ b/src/components/case/expense/table/button/CaseExpenseBillDeleteButton.tsx
@@ -1,12 +1,12 @@
-import { CaseExpenseBIllRowType } from "../../../../../states/case/info/expense/CaseExpenseBIllRowType.tsx";
 import { useSetRecoilState } from "recoil";
 import caseExpenseBillIdState from "../../../../../states/case/info/expense/CaseExpenseBillIdState.tsx";
 import DeleteIcon from "@mui/icons-material/Delete";
 import { Button } from "@mui/material";
 import caseExpenseBillRemovePopUpOpenState from "../../../../../states/case/info/expense/CaseExpenseBillRemovePopUpOpenState.tsx";
+import { CaseExpenseBillRowType } from "../../../../../states/case/info/expense/CaseExpenseBillState.tsx";
 
 type Props = {
-  item: CaseExpenseBIllRowType & { editable: boolean };
+  item: CaseExpenseBillRowType & { editable: boolean };
 };
 
 function CaseExpenseBillDeleteButton({ item }: Props) {

--- a/src/components/case/expense/table/button/CaseExpenseBillEditButton.tsx
+++ b/src/components/case/expense/table/button/CaseExpenseBillEditButton.tsx
@@ -1,13 +1,13 @@
-import caseExpenseBillState, {
-  CaseExpenseBIllRowType,
-} from "../../../../../states/case/info/expense/CaseExpenseBIllRowType.tsx";
 import { useRecoilState } from "recoil";
 import Button from "@mui/material/Button";
 import EditIcon from "@mui/icons-material/Edit";
 import { produce } from "immer";
+import caseExpenseBillState, {
+  CaseExpenseBillRowType,
+} from "../../../../../states/case/info/expense/CaseExpenseBillState.tsx";
 
 type Props = {
-  item: CaseExpenseBIllRowType & { editable: boolean };
+  item: CaseExpenseBillRowType & { editable: boolean };
 };
 function CaseExpenseBillEditButton({ item }: Props) {
   const [expenseBill, setExpenseBill] = useRecoilState(caseExpenseBillState);

--- a/src/components/case/expense/table/button/CaseExpenseBillEditConfirmButton.tsx
+++ b/src/components/case/expense/table/button/CaseExpenseBillEditConfirmButton.tsx
@@ -1,6 +1,3 @@
-import caseExpenseBillState, {
-  CaseExpenseBIllRowType,
-} from "../../../../../states/case/info/expense/CaseExpenseBIllRowType.tsx";
 import { useRecoilState } from "recoil";
 import Button from "@mui/material/Button";
 import CheckIcon from "@mui/icons-material/Check";
@@ -8,9 +5,12 @@ import requestDeprecated, {
   RequestSuccessHandler,
 } from "../../../../../lib/requestDeprecated.ts";
 import { produce } from "immer";
+import caseExpenseBillState, {
+  CaseExpenseBillRowType,
+} from "../../../../../states/case/info/expense/CaseExpenseBillState.tsx";
 
 type Props = {
-  item: CaseExpenseBIllRowType & { editable: boolean };
+  item: CaseExpenseBillRowType & { editable: boolean };
   expenseBillId: number | null;
 };
 function CaseExpenseBillEditConfirmButton({ item, expenseBillId }: Props) {
@@ -20,18 +20,18 @@ function CaseExpenseBillEditConfirmButton({ item, expenseBillId }: Props) {
     const handleSuccess: RequestSuccessHandler = (res) => {
       const body: {
         expenseBillId: number;
-        showFilename: string;
-        originFilename: string;
+        showFileName: string;
+        originFileName: string;
         path: string;
         extension: string;
       } = res.data;
 
-      const { showFilename, originFilename, path, extension } = body;
+      const { showFileName, originFileName, path, extension } = body;
       const newExpenseBill = produce(expenseBill, (draft) => {
         const expenseBill = draft.filter((item2) => item2.id === item.id)[0];
 
-        expenseBill.showFilename = showFilename;
-        expenseBill.originFilename = originFilename;
+        expenseBill.showFileName = showFileName;
+        expenseBill.originFileName = originFileName;
         expenseBill.path = path;
         expenseBill.extension = extension;
       });
@@ -42,8 +42,8 @@ function CaseExpenseBillEditConfirmButton({ item, expenseBillId }: Props) {
     requestDeprecated("PUT", `/files/update/${item.id}`, {
       body: {
         expenseBillId: expenseBillId,
-        showFilename: item.showFilename,
-        originFilename: item.originFilename,
+        showFilename: item.showFileName,
+        originFilename: item.originFileName,
         path: item.path,
         extension: item.extension,
       },

--- a/src/components/case/expense/table/cell/CaseExpenseAmountCell.tsx
+++ b/src/components/case/expense/table/cell/CaseExpenseAmountCell.tsx
@@ -10,10 +10,9 @@ import { delimiter } from "../../../../../lib/convert.ts";
 
 type Props = {
   item: CaseExpenseRowType & { editable: boolean };
-  handleClickRow: any;
 };
 
-function CaseExpenseAmountCell({ item, handleClickRow }: Props) {
+function CaseExpenseAmountCell({ item }: Props) {
   const [expenses, setExpenses] = useRecoilState(CaseExpenseState);
 
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
@@ -48,7 +47,6 @@ function CaseExpenseAmountCell({ item, handleClickRow }: Props) {
         height: 40,
         cursor: "pointer",
       }}
-      onClick={handleClickRow}
     >
       {delimiter(item.amount)}
     </Box>

--- a/src/components/case/expense/table/cell/CaseExpenseAmountCell.tsx
+++ b/src/components/case/expense/table/cell/CaseExpenseAmountCell.tsx
@@ -10,9 +10,10 @@ import { delimiter } from "../../../../../lib/convert.ts";
 
 type Props = {
   item: CaseExpenseRowType & { editable: boolean };
+  handleClickRow: any;
 };
 
-function CaseExpenseAmountCell({ item }: Props) {
+function CaseExpenseAmountCell({ item, handleClickRow }: Props) {
   const [expenses, setExpenses] = useRecoilState(CaseExpenseState);
 
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
@@ -45,7 +46,9 @@ function CaseExpenseAmountCell({ item }: Props) {
         justifyContent: "center",
         alignItems: "center",
         height: 40,
+        cursor: "pointer",
       }}
+      onClick={handleClickRow}
     >
       {delimiter(item.amount)}
     </Box>

--- a/src/components/case/expense/table/cell/CaseExpenseBillShowNameCell.tsx
+++ b/src/components/case/expense/table/cell/CaseExpenseBillShowNameCell.tsx
@@ -1,20 +1,12 @@
-import caseExpenseBillState, {
-  CaseExpenseBIllRowType,
-} from "../../../../../states/case/info/expense/CaseExpenseBIllRowType.tsx";
-import { useRecoilState } from "recoil";
 import Box from "@mui/material/Box";
+import { CaseExpenseBillRowType } from "../../../../../states/case/info/expense/CaseExpenseBillState.tsx";
 
 type Props = {
-  item: CaseExpenseBIllRowType & { editable: boolean };
+  item: CaseExpenseBillRowType & { editable: boolean };
 };
 
 function CaseExpenseBillShowNameCell({ item }: Props) {
-  const [expenseBill, setExpenseBill] = useRecoilState(caseExpenseBillState);
-
-  return item.editable ? (
-    // 파일 업로드 창
-    <Box></Box>
-  ) : (
+  return (
     <Box
       sx={{
         display: "flex",
@@ -23,7 +15,7 @@ function CaseExpenseBillShowNameCell({ item }: Props) {
         height: 40,
       }}
     >
-      {item.showFilename}
+      {item.showFileName + "." + item.extension}
     </Box>
   );
 }

--- a/src/components/case/expense/table/cell/CaseExpenseContentsCell.tsx
+++ b/src/components/case/expense/table/cell/CaseExpenseContentsCell.tsx
@@ -9,10 +9,9 @@ import { ChangeEvent } from "react";
 
 type Props = {
   item: CaseExpenseRowType & { editable: boolean };
-  handleClickRow: any;
 };
 
-function CaseExpenseContentsCell({ item, handleClickRow }: Props) {
+function CaseExpenseContentsCell({ item }: Props) {
   const [expense, setExpense] = useRecoilState(caseExpensesState);
 
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
@@ -45,7 +44,6 @@ function CaseExpenseContentsCell({ item, handleClickRow }: Props) {
         height: 40,
         cursor: "pointer",
       }}
-      onClick={handleClickRow}
     >
       {item.contents}
     </Box>

--- a/src/components/case/expense/table/cell/CaseExpenseContentsCell.tsx
+++ b/src/components/case/expense/table/cell/CaseExpenseContentsCell.tsx
@@ -9,9 +9,10 @@ import { ChangeEvent } from "react";
 
 type Props = {
   item: CaseExpenseRowType & { editable: boolean };
+  handleClickRow: any;
 };
 
-function CaseExpenseContentsCell({ item }: Props) {
+function CaseExpenseContentsCell({ item, handleClickRow }: Props) {
   const [expense, setExpense] = useRecoilState(caseExpensesState);
 
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
@@ -42,7 +43,9 @@ function CaseExpenseContentsCell({ item }: Props) {
         alignItems: "center",
         overflow: "hidden",
         height: 40,
+        cursor: "pointer",
       }}
+      onClick={handleClickRow}
     >
       {item.contents}
     </Box>

--- a/src/components/case/expense/table/cell/CaseExpenseSpeningAtCell.tsx
+++ b/src/components/case/expense/table/cell/CaseExpenseSpeningAtCell.tsx
@@ -10,10 +10,9 @@ import Box from "@mui/material/Box";
 
 type Props = {
   item: CaseExpenseRowType & { editable: boolean };
-  handleClickRow: any;
 };
 
-function CaseExpenseSpeningAtCell({ item, handleClickRow }: Props) {
+function CaseExpenseSpeningAtCell({ item }: Props) {
   const [expenses, setExpenses] = useRecoilState(caseExpensesState);
 
   const handleChange = (e: Dayjs | null) => {
@@ -45,7 +44,6 @@ function CaseExpenseSpeningAtCell({ item, handleClickRow }: Props) {
         height: 40,
         cursor: "pointer",
       }}
-      onClick={handleClickRow}
     >
       {item.speningAt}
     </Box>

--- a/src/components/case/expense/table/cell/CaseExpenseSpeningAtCell.tsx
+++ b/src/components/case/expense/table/cell/CaseExpenseSpeningAtCell.tsx
@@ -10,9 +10,10 @@ import Box from "@mui/material/Box";
 
 type Props = {
   item: CaseExpenseRowType & { editable: boolean };
+  handleClickRow: any;
 };
 
-function CaseExpenseSpeningAtCell({ item }: Props) {
+function CaseExpenseSpeningAtCell({ item, handleClickRow }: Props) {
   const [expenses, setExpenses] = useRecoilState(caseExpensesState);
 
   const handleChange = (e: Dayjs | null) => {
@@ -42,7 +43,9 @@ function CaseExpenseSpeningAtCell({ item }: Props) {
         justifyContent: "center",
         alignItems: "center",
         height: 40,
+        cursor: "pointer",
       }}
+      onClick={handleClickRow}
     >
       {item.speningAt}
     </Box>

--- a/src/components/case/expense/table/popup/CaseExpenseAddPopUp.tsx
+++ b/src/components/case/expense/table/popup/CaseExpenseAddPopUp.tsx
@@ -62,7 +62,7 @@ function CaseExpenseAddPopUp() {
         }: { expenses: CaseExpenseRowType[]; size: number } = res.data;
         setExpenses(
           expenses.map((item) => {
-            return { ...item, editable: false };
+            return { ...item, editable: false, isSelected: false };
           }),
         );
         setSize(size);

--- a/src/components/case/expense/table/popup/CaseExpenseRemovePopUp.tsx
+++ b/src/components/case/expense/table/popup/CaseExpenseRemovePopUp.tsx
@@ -37,7 +37,7 @@ function CaseExpenseRemovePopUp() {
         }: { expenses: CaseExpenseRowType[]; size: number } = res.data;
         setExpenses(
           expenses.map((item) => {
-            return { ...item, editable: false };
+            return { ...item, editable: false, isSelected: false };
           }),
         );
 

--- a/src/components/case/expense/table/row/CaseExpenseBillDataRow.tsx
+++ b/src/components/case/expense/table/row/CaseExpenseBillDataRow.tsx
@@ -1,22 +1,35 @@
-import { CaseExpenseBIllRowType } from "../../../../../states/case/info/expense/CaseExpenseBIllRowType.tsx";
 import Box from "@mui/material/Box";
 import CaseExpenseBillShowNameCell from "../cell/CaseExpenseBillShowNameCell.tsx";
 import CaseExpenseBillEditConfirmButton from "../button/CaseExpenseBillEditConfirmButton.tsx";
 import CaseExpenseBillEditButton from "../button/CaseExpenseBillEditButton.tsx";
 import CaseExpenseBillDeleteButton from "../button/CaseExpenseBillDeleteButton.tsx";
+import { CaseExpenseBillRowType } from "../../../../../states/case/info/expense/CaseExpenseBillState.tsx";
 
 type Props = {
-  item: CaseExpenseBIllRowType & { editable: boolean };
+  item: CaseExpenseBillRowType & { editable: boolean };
   expenseBillId: number | null;
 };
+
 function CaseExpenseBillDataRow({ item, expenseBillId }: Props) {
   return (
     <Box sx={{ display: "flex", width: "100%", height: 40 }}>
-      <Box>
+      <Box
+        sx={{
+          width: 300,
+          minWidth: 150,
+        }}
+      >
         <CaseExpenseBillShowNameCell item={item} />
       </Box>
       <Box sx={{ display: "flex", width: 150, minWidth: 150 }}>
-        <Box>
+        <Box
+          sx={{
+            width: "100%",
+            display: "flex",
+            justifyContent: "center",
+            alignItems: "center",
+          }}
+        >
           {item.editable ? (
             <CaseExpenseBillEditConfirmButton
               item={item}

--- a/src/components/case/expense/table/row/CaseExpenseBillHeaderRow.tsx
+++ b/src/components/case/expense/table/row/CaseExpenseBillHeaderRow.tsx
@@ -1,8 +1,53 @@
 import Box from "@mui/material/Box";
 import TableCell from "@mui/material/TableCell";
 import { Button } from "@mui/material";
+import { ChangeEvent, useRef } from "react";
+import requestDeprecated, {
+  RequestFailHandler,
+  RequestSuccessHandler,
+} from "../../../../../lib/requestDeprecated.ts";
+import { useRecoilValue } from "recoil";
+import caseExpenseIdState from "../../../../../states/case/info/expense/CaseExpenseIdState.tsx";
 
-function CaseExpenseBillHeaderRow() {
+type Props = {
+  setTrigger: any;
+};
+
+function CaseExpenseBillHeaderRow({ setTrigger }: Props) {
+  const expenseId = useRecoilValue(caseExpenseIdState);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+
+  const handleFileInputChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const selectedFile = event.target.files?.[0];
+
+    if (selectedFile) {
+      const formData = new FormData();
+      formData.append("file", selectedFile);
+
+      const handleRequestSuccess: RequestSuccessHandler = () => {
+        setTrigger(true);
+      };
+
+      const handleRequestFail: RequestFailHandler = (e) => {
+        alert((e.response.data as { code: string; message: string }).message);
+      };
+
+      // formData 서버로 전송
+      requestDeprecated("POST", `/expenses/${expenseId}/bill`, {
+        body: formData,
+        onSuccess: handleRequestSuccess,
+        onFail: handleRequestFail,
+      });
+    }
+  };
+
+  const handleExpenseBillAddButtonClick = () => {
+    // 파일 선택을 위한 input 요소 클릭
+    if (fileInputRef.current) {
+      fileInputRef.current.click();
+    }
+  };
+
   return (
     <Box sx={{ display: "flex", width: "100%" }}>
       <Box
@@ -37,9 +82,17 @@ function CaseExpenseBillHeaderRow() {
           alignItems: "center",
         }}
       >
+        <input
+          type="file"
+          accept=".jpg, .jpeg, .png, .gif" // 허용할 파일 확장자를 지정
+          style={{ display: "none" }}
+          ref={fileInputRef}
+          onChange={handleFileInputChange}
+        />
         <Button
           variant="contained"
           sx={{ width: "100%", color: "secondary", fontSize: 16 }}
+          onClick={handleExpenseBillAddButtonClick}
         >
           등록
         </Button>

--- a/src/components/case/expense/table/row/CaseExpenseDataRow.tsx
+++ b/src/components/case/expense/table/row/CaseExpenseDataRow.tsx
@@ -1,23 +1,58 @@
 import Box from "@mui/material/Box";
-import { CaseExpenseRowType } from "../../../../../states/case/info/expense/CaseExpensesState.tsx";
+import CaseExpensesState, {
+  CaseExpenseRowType,
+} from "../../../../../states/case/info/expense/CaseExpensesState.tsx";
 import CaseExpenseContentsCell from "../cell/CaseExpenseContentsCell.tsx";
 import CaseExpenseSpeningAtCell from "../cell/CaseExpenseSpeningAtCell.tsx";
 import CaseExpenseAmountCell from "../cell/CaseExpenseAmountCell.tsx";
 import CaseExpenseEditConfirmButton from "../button/CaseExpenseEditConfirmButton.tsx";
 import CaseExpenseEditButton from "../button/CaseExpenseEditButton.tsx";
 import CaseExpenseDeleteButton from "../button/CaseExpenseDeleteButton.tsx";
-import { useSetRecoilState } from "recoil";
-import caseExpenseIdState from "../../../../../states/case/info/expense/CaseExpenseIdState.tsx";
+import { useRecoilState, useSetRecoilState } from "recoil";
+import requestDeprecated, {
+  RequestSuccessHandler,
+} from "../../../../../lib/requestDeprecated.ts";
+import caseExpenseBillState, {
+  CaseExpenseBillRowType,
+} from "../../../../../states/case/info/expense/CaseExpenseBillState.tsx";
+import { produce } from "immer";
 
 type Props = {
-  item: CaseExpenseRowType & { editable: boolean };
+  item: CaseExpenseRowType & { editable: boolean; isSelected: boolean };
   caseId: number | null;
 };
 
 function CaseExpenseDataRow({ item, caseId }: Props) {
-  const setExpenseId = useSetRecoilState(caseExpenseIdState);
-  const handleClickRow = () => {
-    setExpenseId(item.id);
+  const [expenses, setExpenses] = useRecoilState(CaseExpensesState);
+  const setExpenseBill = useSetRecoilState(caseExpenseBillState);
+
+  const handleClickRow = (expenseId: number) => {
+    const newExpenses = produce(expenses, (draft) => {
+      for (const d of draft) {
+        d.isSelected = false;
+      }
+      const expense = draft.filter((item2) => item2.id === item.id)[0];
+      expense.isSelected = true;
+    });
+    setExpenses(newExpenses);
+
+    if (expenseId === null) {
+      return;
+    }
+
+    const handleRequestSuccess: RequestSuccessHandler = (res) => {
+      const expenseBill: CaseExpenseBillRowType[] = res.data;
+
+      setExpenseBill(
+        expenseBill.map((item) => {
+          return { ...item, editable: false };
+        }),
+      );
+    };
+
+    requestDeprecated("GET", `/expenses/${expenseId}/bill`, {
+      onSuccess: handleRequestSuccess,
+    });
   };
 
   return (
@@ -26,16 +61,27 @@ function CaseExpenseDataRow({ item, caseId }: Props) {
         display: "flex",
         width: "100%",
         height: 40,
+        minWidth: "715.69px",
+        background: item.isSelected ? "lightgray" : "none",
       }}
     >
-      <Box sx={{ width: 200, minWidth: 150 }}>
-        <CaseExpenseSpeningAtCell item={item} handleClickRow={handleClickRow} />
+      <Box
+        sx={{ width: 200, minWidth: 150 }}
+        onClick={() => handleClickRow(item.id)}
+      >
+        <CaseExpenseSpeningAtCell item={item} />
       </Box>
-      <Box sx={{ width: 500, minWidth: 200 }}>
-        <CaseExpenseContentsCell item={item} handleClickRow={handleClickRow} />
+      <Box
+        sx={{ width: 500, minWidth: 200 }}
+        onClick={() => handleClickRow(item.id)}
+      >
+        <CaseExpenseContentsCell item={item} />
       </Box>
-      <Box sx={{ width: 200, minWidth: 100 }}>
-        <CaseExpenseAmountCell item={item} handleClickRow={handleClickRow} />
+      <Box
+        sx={{ width: 200, minWidth: 100 }}
+        onClick={() => handleClickRow(item.id)}
+      >
+        <CaseExpenseAmountCell item={item} />
       </Box>
       <Box sx={{ display: "flex", width: 150, minWidth: 150 }}>
         <Box

--- a/src/components/case/expense/table/row/CaseExpenseDataRow.tsx
+++ b/src/components/case/expense/table/row/CaseExpenseDataRow.tsx
@@ -6,6 +6,8 @@ import CaseExpenseAmountCell from "../cell/CaseExpenseAmountCell.tsx";
 import CaseExpenseEditConfirmButton from "../button/CaseExpenseEditConfirmButton.tsx";
 import CaseExpenseEditButton from "../button/CaseExpenseEditButton.tsx";
 import CaseExpenseDeleteButton from "../button/CaseExpenseDeleteButton.tsx";
+import { useSetRecoilState } from "recoil";
+import caseExpenseIdState from "../../../../../states/case/info/expense/CaseExpenseIdState.tsx";
 
 type Props = {
   item: CaseExpenseRowType & { editable: boolean };
@@ -13,6 +15,11 @@ type Props = {
 };
 
 function CaseExpenseDataRow({ item, caseId }: Props) {
+  const setExpenseId = useSetRecoilState(caseExpenseIdState);
+  const handleClickRow = () => {
+    setExpenseId(item.id);
+  };
+
   return (
     <Box
       sx={{
@@ -22,13 +29,13 @@ function CaseExpenseDataRow({ item, caseId }: Props) {
       }}
     >
       <Box sx={{ width: 200, minWidth: 150 }}>
-        <CaseExpenseSpeningAtCell item={item} />
+        <CaseExpenseSpeningAtCell item={item} handleClickRow={handleClickRow} />
       </Box>
       <Box sx={{ width: 500, minWidth: 200 }}>
-        <CaseExpenseContentsCell item={item} />
+        <CaseExpenseContentsCell item={item} handleClickRow={handleClickRow} />
       </Box>
       <Box sx={{ width: 200, minWidth: 100 }}>
-        <CaseExpenseAmountCell item={item} />
+        <CaseExpenseAmountCell item={item} handleClickRow={handleClickRow} />
       </Box>
       <Box sx={{ display: "flex", width: 150, minWidth: 150 }}>
         <Box

--- a/src/lib/requestDeprecated.ts
+++ b/src/lib/requestDeprecated.ts
@@ -20,7 +20,7 @@ function requestDeprecated(
   path: string,
   config?: {
     withToken?: boolean;
-    body?: Record<string, unknown>;
+    body?: Record<string, unknown> | FormData;
     params?: Record<string, string>;
     headers?: Record<string, string>;
     timeout?: number;

--- a/src/states/case/info/expense/CaseExpenseBillState.tsx
+++ b/src/states/case/info/expense/CaseExpenseBillState.tsx
@@ -1,15 +1,15 @@
 import { atom } from "recoil";
 
-export type CaseExpenseBIllRowType = {
+export type CaseExpenseBillRowType = {
   id: number;
-  showFilename: string;
-  originFilename: string;
+  showFileName: string;
+  originFileName: string;
   path: string;
   extension: string;
 };
 
 const caseExpenseBillState = atom<
-  (CaseExpenseBIllRowType & { editable: boolean })[]
+  (CaseExpenseBillRowType & { editable: boolean })[]
 >({
   key: "caseExpenseBillState",
   default: [],

--- a/src/states/case/info/expense/CaseExpensesState.tsx
+++ b/src/states/case/info/expense/CaseExpensesState.tsx
@@ -7,7 +7,9 @@ export type CaseExpenseRowType = {
   amount: number;
 };
 
-const caseExpensesState = atom<(CaseExpenseRowType & { editable: boolean })[]>({
+const caseExpensesState = atom<
+  (CaseExpenseRowType & { editable: boolean; isSelected: boolean })[]
+>({
   key: "caseExpensesState",
   default: [],
 });


### PR DESCRIPTION
지출 테이블에서 특정 지출 Row를 클릭하면 해당 지출에 대한 업로드된 파일 목록이 나온다.

해당 파일 테이블에서 등록 버튼 클릭시 파일을 업로드할 수 있는 기능을 BackEnd와 연동하여 구현하였다.