### PR TITLE
fix: expenseBillTable 출력 메시지 수정

### DIFF
--- a/src/components/case/expense/table/CaseExpenseBillTable.tsx
+++ b/src/components/case/expense/table/CaseExpenseBillTable.tsx
@@ -83,7 +83,7 @@ function CaseExpenseBillTable() {
           expenseBill.map((item) => (
             <CaseExpenseBillDataRow key={item.id} item={item} />
           ))
-        ) : (
+        ) : expenseId ? (
           <Box
             sx={{
               width: "100%",
@@ -94,6 +94,18 @@ function CaseExpenseBillTable() {
             }}
           >
             자료가 없습니다.
+          </Box>
+        ) : (
+          <Box
+            sx={{
+              width: "100%",
+              height: 200,
+              display: "flex",
+              justifyContent: "center",
+              alignItems: "center",
+            }}
+          >
+            지출 항목을 선택해주세요.
           </Box>
         )
       ) : (


### PR DESCRIPTION
지출 증빙자료 테이블에서 지출 항목이 선택 안되있으면 '지출 항목을 선택해주세요.' 메시지 출력.

지출 항목이 선택되어 있지만 해당 지출에 대한 자료가 없으면 '자료가 없습니다.' 메시지 출력.