### PR TITLE
지원/관리자 권환별 사원 랜더링

### DIFF
--- a/src/components/chat/socket.ts
+++ b/src/components/chat/socket.ts
@@ -3,7 +3,7 @@ import { io } from "socket.io-client";
 const socket = io(
   import.meta.env.DEV
     ? "http://localhost:7777"
-    : "https://lawsuit-management-api.store:7778",
+    : "https://lawsuit-management-api.store:7777",
 );
 
 export default socket;

--- a/src/components/employee/case/info/EmployeeInfoCard.tsx
+++ b/src/components/employee/case/info/EmployeeInfoCard.tsx
@@ -38,6 +38,7 @@ import BalanceIcon from "@mui/icons-material/Balance";
 import snbLoadedState from "../../../../states/common/SnbLoadedState";
 import subNavigationBarState from "../../../../states/layout/SubNavigationBarState";
 import caseIdState from "../../../../states/case/CaseIdState";
+import { isAdminState } from "../../../../states/user/UserState";
 
 type Props = {
   width?: string | number;
@@ -87,6 +88,8 @@ function EmployeeInfoCard({
   const [phoneMessage, setPhoneMessage] = useState("");
   const [isAddressDetailOk, setIsAddressDetailOk] = useState(true);
   const [addressDetailMessage, setAddressDetailMessage] = useState("");
+
+  const isAdmin = useRecoilValue(isAdminState);
 
   const onPhoneChange = (
     e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
@@ -338,7 +341,7 @@ function EmployeeInfoCard({
                 </>
               ) : (
                 <>
-                  {isEditable ? (
+                  {isEditable && isAdmin ? (
                     <Button
                       variant="outlined"
                       size="small"

--- a/src/components/employee/case/list/EmployeeCaseListTable.tsx
+++ b/src/components/employee/case/list/EmployeeCaseListTable.tsx
@@ -21,6 +21,7 @@ import NormalDialog from "../../../common/dialog/NormalDialog";
 import Card from "@mui/material/Card";
 import CardTitle from "../../../common/CardTitle";
 import { HeadCell } from "../../../case/type/HeadCell";
+import { isAdminState } from "../../../../states/user/UserState";
 
 type Props = {
   cases: (LawsuitInfo & { onClick: () => void })[];
@@ -49,6 +50,8 @@ function EmployeeCaseListTable({
   sortOrder,
   setSortOrder,
 }: Props) {
+  const isAdmin = useRecoilValue(isAdminState);
+
   const employeeId = useRecoilValue(employeeIdState);
   const [isRemoveConfirmOpen, setIsRemoveConfirmOpen] = useState(false);
   const [selectedLawsuitId, setSelectedLawsuitId] = useState<number | null>(
@@ -125,7 +128,7 @@ function EmployeeCaseListTable({
       id: "name",
       label: "사건명",
       canSort: true,
-      width: "20%",
+      width: "25%",
     },
     {
       id: "lawsuitNum",
@@ -143,27 +146,33 @@ function EmployeeCaseListTable({
       id: "commissionFee",
       label: "의뢰비",
       canSort: true,
-      width: "10%",
+      width: "15%",
     },
     {
       id: "contingentFee",
       label: "성공보수",
       canSort: true,
-      width: "10%",
+      width: "15%",
     },
     {
       id: "createdAt",
       label: "등록일",
       canSort: true,
-      width: "15%",
-    },
-    {
-      id: "remove",
-      label: "담당자 제거",
-      canSort: false,
       width: "10%",
     },
   ];
+
+  if (isAdmin) {
+    headCells.push({
+      id: "remove",
+      label: "담당자 제거",
+      canSort: false,
+      width: "15%",
+    });
+    headCells.find((cell) => cell.id === "contingentFee")!.width = "10%";
+    headCells.find((cell) => cell.id === "commissionFee")!.width = "10%";
+    headCells.find((cell) => cell.id === "lawsuitNum")!.width = "10%";
+  }
 
   return (
     <>
@@ -192,7 +201,7 @@ function EmployeeCaseListTable({
                   !headCell.canSort ? (
                     <TableCell
                       key={headCell.id}
-                      align="left"
+                      align="center"
                       style={{ width: headCell.width }}
                     >
                       <b>{headCell.label}</b>
@@ -200,10 +209,14 @@ function EmployeeCaseListTable({
                   ) : (
                     <TableCell
                       key={headCell.id}
-                      align="left"
+                      align="center"
                       style={{ width: headCell.width }}
                     >
                       <TableSortLabel
+                        sx={{
+                          align: "center",
+                          marginLeft: "25px",
+                        }}
                         active={sortKey === headCell.id}
                         direction={sortKey === headCell.id ? sortOrder : "asc"}
                         onClick={() => {
@@ -230,7 +243,7 @@ function EmployeeCaseListTable({
                     onClick={item.onClick}
                   >
                     <TableCell
-                      align="left"
+                      align="center"
                       component="th"
                       scope="row"
                       style={{ width: headCells[0].width }}
@@ -238,57 +251,59 @@ function EmployeeCaseListTable({
                       {page * rowsPerPage + index + 1}
                     </TableCell>
                     <TableCell
-                      align="left"
+                      align="center"
                       style={{ width: headCells[1].width }}
                     >
                       {item.name}
                     </TableCell>
                     <TableCell
-                      align="left"
+                      align="center"
                       style={{ width: headCells[2].width }}
                     >
                       {item.lawsuitNum ? item.lawsuitNum : "-"}
                     </TableCell>
                     <TableCell
-                      align="left"
+                      align="center"
                       style={{ width: headCells[3].width }}
                     >
                       {item.lawsuitStatus}
                     </TableCell>
                     <TableCell
-                      align="left"
+                      align="center"
                       style={{ width: headCells[4].width }}
                     >
                       {delimiter(item.commissionFee)}
                     </TableCell>
                     <TableCell
-                      align="left"
+                      align="center"
                       style={{ width: headCells[5].width }}
                     >
                       {delimiter(item.contingentFee)}
                     </TableCell>
                     <TableCell
-                      align="left"
+                      align="center"
                       style={{ width: headCells[6].width }}
                     >
                       {item.createdAt.toString().substring(0, 10)}
                     </TableCell>
-                    <TableCell
-                      align="left"
-                      style={{ width: headCells[7].width }}
-                    >
-                      <Button
-                        variant="contained"
-                        color="primary"
-                        onClick={(event) => {
-                          event.stopPropagation();
-                          setIsRemoveConfirmOpen(true);
-                          setSelectedLawsuitId(item.id);
-                        }}
+                    {isAdmin && (
+                      <TableCell
+                        align="center"
+                        style={{ width: headCells[7].width }}
                       >
-                        담당자 제거
-                      </Button>
-                    </TableCell>
+                        <Button
+                          variant="contained"
+                          color="primary"
+                          onClick={(event) => {
+                            event.stopPropagation();
+                            setIsRemoveConfirmOpen(true);
+                            setSelectedLawsuitId(item.id);
+                          }}
+                        >
+                          담당자 제거
+                        </Button>
+                      </TableCell>
+                    )}
                   </TableRow>
                 ))}
               </TableBody>
@@ -298,7 +313,7 @@ function EmployeeCaseListTable({
                   align="center"
                   component="th"
                   scope="row"
-                  colSpan={8}
+                  colSpan={isAdmin ? 8 : 7}
                 >
                   <br />
                   담당 사건이 없습니다.
@@ -310,7 +325,10 @@ function EmployeeCaseListTable({
 
             <TableFooter>
               <TableRow>
-                <TableCell colSpan={8} style={{ textAlign: "center" }}>
+                <TableCell
+                  colSpan={isAdmin ? 8 : 7}
+                  style={{ textAlign: "center" }}
+                >
                   <TablePagination
                     sx={{ display: "inline-flex", verticalAlign: "middle" }}
                     rowsPerPageOptions={[5, 10, 25]}

--- a/src/components/employee/case/list/EmployeeCaseListTable.tsx
+++ b/src/components/employee/case/list/EmployeeCaseListTable.tsx
@@ -246,7 +246,7 @@ function EmployeeCaseListTable({
                       align="center"
                       component="th"
                       scope="row"
-                      style={{ width: headCells[0].width }}
+                      style={{ width: headCells[0].width, height: "65px" }}
                     >
                       {page * rowsPerPage + index + 1}
                     </TableCell>
@@ -291,17 +291,22 @@ function EmployeeCaseListTable({
                         align="center"
                         style={{ width: headCells[7].width }}
                       >
-                        <Button
-                          variant="contained"
-                          color="primary"
-                          onClick={(event) => {
-                            event.stopPropagation();
-                            setIsRemoveConfirmOpen(true);
-                            setSelectedLawsuitId(item.id);
-                          }}
-                        >
-                          담당자 제거
-                        </Button>
+                        {item.lawsuitStatus !== "종결" ? (
+                          <Button
+                            size="small"
+                            variant="contained"
+                            color="primary"
+                            onClick={(event) => {
+                              event.stopPropagation();
+                              setIsRemoveConfirmOpen(true);
+                              setSelectedLawsuitId(item.id);
+                            }}
+                          >
+                            담당자 제거
+                          </Button>
+                        ) : (
+                          <span style={{ color: "red" }}>종결사건</span>
+                        )}
                       </TableCell>
                     )}
                   </TableRow>

--- a/src/components/employee/list/EmployeeListTable.tsx
+++ b/src/components/employee/list/EmployeeListTable.tsx
@@ -96,12 +96,16 @@ function EmployeeListTable({
             <TableRow>
               {headCells.map((headCell) =>
                 !headCell.canSort ? (
-                  <TableCell align="left" style={{ width: headCell.width }}>
+                  <TableCell align="center" style={{ width: headCell.width }}>
                     <b>{headCell.label}</b>
                   </TableCell>
                 ) : (
-                  <TableCell align="left" style={{ width: headCell.width }}>
+                  <TableCell align="center" style={{ width: headCell.width }}>
                     <TableSortLabel
+                      sx={{
+                        align: "center",
+                        marginLeft: "25px",
+                      }}
                       active={sortKey === headCell.id}
                       direction={sortKey === headCell.id ? sortOrder : "asc"}
                       onClick={() => {
@@ -134,23 +138,23 @@ function EmployeeListTable({
                 >
                   {page * rowsPerPage + index + 1}
                 </TableCell>
-                <TableCell align="left" style={{ width: headCells[1].width }}>
+                <TableCell align="center" style={{ width: headCells[1].width }}>
                   {item.name}
                 </TableCell>
-                <TableCell align="left" style={{ width: headCells[2].width }}>
+                <TableCell align="center" style={{ width: headCells[2].width }}>
                   {hierarchyMap[item.hierarchyId]?.nameKr ?? "N/A"}
                 </TableCell>
-                <TableCell align="left" style={{ width: headCells[3].width }}>
+                <TableCell align="center" style={{ width: headCells[3].width }}>
                   {roleMap[item.roleId]?.nameKr ?? "N/A"}
                 </TableCell>
 
-                <TableCell align="left" style={{ width: headCells[4].width }}>
+                <TableCell align="center" style={{ width: headCells[4].width }}>
                   {item.phone}
                 </TableCell>
-                <TableCell align="left" style={{ width: headCells[5].width }}>
+                <TableCell align="center" style={{ width: headCells[5].width }}>
                   {item.email}
                 </TableCell>
-                <TableCell align="left" style={{ width: headCells[6].width }}>
+                <TableCell align="center" style={{ width: headCells[6].width }}>
                   {item.createdAt}
                 </TableCell>
               </TableRow>

--- a/src/states/user/UserState.ts
+++ b/src/states/user/UserState.ts
@@ -26,4 +26,15 @@ export const isEmployeeState = selector<boolean>({
   },
 });
 
+export const isAdminState = selector<boolean>({
+  key: "isAdminState",
+  get: ({ get }) => {
+    const user = get(userState);
+    if (!user) {
+      return false;
+    }
+    return user.roleId !== 2;
+  },
+});
+
 export default userState;


### PR DESCRIPTION
1. 일반 직원은 사원정보 수정 버튼 안보이게 하기
2. 일반 직원은 담당자 제거 안보이게 하기
3. 종결사건의 경우에는 담당자 제거 대신 "종결"